### PR TITLE
feat: add Claude Code Special event (Jan 20, 2026)

### DIFF
--- a/src/components/EventCards.astro
+++ b/src/components/EventCards.astro
@@ -26,24 +26,15 @@ export interface Props {
 // Default events if none provided - focusing on next Luma event
 const defaultEvents: Event[] = [
   {
-    title: "Agentic Coding Meetup #3",
-    date: "November 25, 2025",
-    time: "18:00 - 20:00 CET",
-    location: "Factorial GmbH, Hamburg",
-    spotsAvailable: 3,
+    title: "Claude Code Special",
+    date: "January 20, 2026",
+    time: "18:00 - 23:00 CET",
+    location: "Engel & Völkers HQ, Hamburg",
+    spotsAvailable: 150,
     description:
-      "4 talks on agentic coding plus networking! 107+ attendees confirmed.",
-    registrationUrl: "https://luma.com/dicrp3xl",
+      "A special Claude Code meetup as part of the global Claude Community Events series. Live demos, talks, and networking with Hamburg's agentic coding community.",
+    registrationUrl: "https://luma.com/4c9hr63k",
     type: "meetup",
-    agenda: [
-      { time: "18:00", title: "Open Doors" },
-      { time: "18:30", title: "Headless Claude Code in the Wild", speaker: "Sebastian Korfmann" },
-      { time: "18:50", title: "Agentic AI for SEO Content Generation", speaker: "Guruprasad P" },
-      { time: "19:10", title: "Break" },
-      { time: "19:30", title: "FlowDrop: AI Agentic and Automation Workflow", speaker: "Volkan Jacobsen" },
-      { time: "19:50", title: "OpenCode – The Freedom of Choice for Agentic Coding", speaker: "Daniel Moll" },
-      { time: "20:10", title: "Networking & Drinks" },
-    ],
   },
 ];
 
@@ -143,7 +134,7 @@ const { events = defaultEvents } = Astro.props;
                     </svg>
                   </a>
                   <a
-                    href="https://www.meetup.com/agentic-coding-meetup-hamburg/events/311692803/"
+                    href="https://www.meetup.com/agentic-coding-meetup-hamburg/events/312554567/"
                     target="_blank"
                     rel="noopener noreferrer"
                     class="event-secondary-link"

--- a/src/components/PastEvents.astro
+++ b/src/components/PastEvents.astro
@@ -33,6 +33,15 @@ const defaultEvents: PastEvent[] = [
     attendees: 92,
     url: "https://www.meetup.com/agentic-coding-meetup-hamburg/events/310792806/",
   },
+  {
+    title: "Meetup #3",
+    number: 3,
+    date: "November 25, 2025",
+    location: "Hamburg",
+    sponsor: "Factorial GmbH",
+    attendees: 100,
+    url: "https://www.meetup.com/agentic-coding-meetup-hamburg/events/311692803/",
+  },
 ];
 
 const { events = defaultEvents } = Astro.props;


### PR DESCRIPTION
## Summary
- Add **Claude Code Special** as the upcoming event (January 20, 2026 at Engel & Völkers HQ)
- Move completed **Meetup #3** (Nov 25, 2025) to past events section
- Update registration links for Luma and Meetup.com

## Event Details
- **Date:** January 20, 2026 | 18:00 - 23:00 CET
- **Location:** Engel & Völkers Headquarters, Hamburg
- **Capacity:** 150 spots
- **Part of:** Global Claude Community Events series

## Test plan
- [ ] Verify landing page displays Claude Code Special as upcoming event
- [ ] Confirm Meetup #3 appears in past events timeline with correct details
- [ ] Test registration links (Luma + Meetup.com)
- [ ] Check responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)