### PR TITLE
Update RSVP counts for Claude Code Special

### DIFF
--- a/src/components/EventCards.astro
+++ b/src/components/EventCards.astro
@@ -30,9 +30,9 @@ const defaultEvents: Event[] = [
     date: "January 20, 2026",
     time: "18:00 - 23:00 CET",
     location: "Engel & Völkers HQ, Hamburg",
-    spotsAvailable: 150,
+    spotsAvailable: 15,
     description:
-      "A special Claude Code meetup as part of the global Claude Community Events series. Live demos, talks, and networking with Hamburg's agentic coding community.",
+      "A special Claude Code meetup as part of the global Claude Community Events series. 180+ attendees confirmed — limited spots still available! Live demos, talks, and networking.",
     registrationUrl: "https://luma.com/4c9hr63k",
     type: "meetup",
   },


### PR DESCRIPTION
## Summary
- Updated spots available from 150 → 15 (based on Luma availability)
- Added "180+ attendees confirmed" to description (45 Luma + 137 Meetup)
- Resolved merge conflict with stashed changes

## Test plan
- [ ] Verify event card displays correct spots count
- [ ] Verify description shows updated attendee count

🤖 Generated with [Claude Code](https://claude.com/claude-code)