### PR TITLE
feat: add legal pages and unify contact email

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -22,6 +22,8 @@ const t = useTranslations();
       <p class="mt-2 text-center font-mono text-sm text-gray-500">
         Built with ❤️ in Hamburg •
         <a href="/imprint" class="link">{t.footer.imprint}</a> •
+        <a href="/privacy" class="link">Privacy</a> •
+        <a href="/tos" class="link">Terms</a> •
         <a
           href="https://www.meetup.com/agentic-coding-meetup-hamburg"
           target="_blank"

--- a/src/pages/imprint.astro
+++ b/src/pages/imprint.astro
@@ -7,7 +7,7 @@ import { useTranslations } from "../lib/i18n/utils";
 const t = useTranslations();
 ---
 
-<Layout title="Imprint - OnTree">
+<Layout title="Imprint - Agentic Hamburg">
   <Header />
 
   <div class="imprint-container flex min-h-screen flex-col">
@@ -25,52 +25,119 @@ const t = useTranslations();
         </h3>
 
         <p class="company-info">
-          Gannet Development GmbH<br />
-          Represented by: Stefan Munz<br />
-          Telemannstrasse 21<br />
-          20255 Hamburg<br />
+          Korfmann Ventures UG (haftungsbeschränkt)<br />
+          Parkallee 7<br />
+          20144 Hamburg<br />
           Germany
         </p>
 
-        <p class="mt-4">Email: mail [at] gannet [dot] dev</p>
-        <p>
-          Website: <a
-            href="https://www.gannet.dev"
-            class="imprint-link"
-            target="_blank"
-            rel="noopener noreferrer">www.gannet.dev</a
-          >
+        <p class="mt-4">
+          Handelsregister: HRB 177270<br />
+          Registergericht: Amtsgericht Hamburg<br />
+          USt-IdNr: DE 355878498<br />
+          Geschäftsführer: Sebastian Korfmann
         </p>
+
+        <p class="mt-4">Email: <a href="mailto:hello@agentic.hamburg">hello@agentic.hamburg</a></p>
       </div>
 
-      <!-- Registration Information -->
-      <h3 class="section-heading pb-2 pt-4 text-xl leading-8 tracking-tight">
-        Registereintrag
+      <!-- Legal Entity -->
+      <h3 class="section-heading pb-2 pt-6 text-xl leading-8 tracking-tight font-semibold">
+        Legal Entity
       </h3>
-      <p>Registergericht: Amtsgericht Hamburg</p>
-      <p>Registernummer: HRB 191805</p>
+      <p>
+        Agentic Conf Hamburg is organized by Korfmann Ventures UG (haftungsbeschränkt),
+        a company registered in Hamburg, Germany. All ticket sales, contracts, and legal
+        obligations related to the conference are entered into with Korfmann Ventures UG.
+      </p>
 
       <!-- Responsibility Information -->
-      <h3 class="section-heading pb-2 pt-4 text-xl leading-8 tracking-tight">
+      <h3 class="section-heading pb-2 pt-6 text-xl leading-8 tracking-tight font-semibold">
         Responsible for content according to § 55 Abs. 2 RStV
       </h3>
       <p>
-        Stefan Munz<br />
-        Gannet Development GmbH<br />
-        Telemannstrasse 21<br />
-        20255 Hamburg
+        Sebastian Korfmann<br />
+        Korfmann Ventures UG (haftungsbeschränkt)<br />
+        Parkallee 7<br />
+        20144 Hamburg
       </p>
 
-      <!-- Liability Notice -->
-      <h3 class="section-heading pb-2 pt-4 text-xl leading-8 tracking-tight">
-        Liability Notice
+      <!-- Dispute Resolution -->
+      <h3 class="section-heading pb-2 pt-6 text-xl leading-8 tracking-tight font-semibold">
+        Streitschlichtung
       </h3>
       <p>
-        Despite careful content control, we don't take any liability for the
-        content of external links. The content of the linked pages is the sole
-        responsibility of their operators. If you find a link on this website
-        that links to websites that violate applicable law, please let us know
-        so that we can remove the link.
+        Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS)
+        bereit: <a
+          href="https://ec.europa.eu/consumers/odr/"
+          class="imprint-link"
+          target="_blank"
+          rel="noopener noreferrer">https://ec.europa.eu/consumers/odr/</a
+        >
+      </p>
+      <p class="mt-2">
+        Unsere E-Mail-Adresse finden Sie oben im Impressum.
+      </p>
+      <p class="mt-2">
+        Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer
+        Verbraucherschlichtungsstelle teilzunehmen.
+      </p>
+
+      <!-- Liability for Content -->
+      <h3 class="section-heading pb-2 pt-6 text-xl leading-8 tracking-tight font-semibold">
+        Haftung für Inhalte
+      </h3>
+      <p>
+        Als Diensteanbieter sind wir gemäß § 7 Abs.1 TMG für eigene Inhalte auf diesen
+        Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind
+        wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte
+        fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine
+        rechtswidrige Tätigkeit hinweisen.
+      </p>
+      <p class="mt-2">
+        Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach
+        den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung
+        ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung
+        möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen werden wir diese
+        Inhalte umgehend entfernen.
+      </p>
+
+      <!-- Liability for Links -->
+      <h3 class="section-heading pb-2 pt-6 text-xl leading-8 tracking-tight font-semibold">
+        Haftung für Links
+      </h3>
+      <p>
+        Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir
+        keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine
+        Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige
+        Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden
+        zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige
+        Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar.
+      </p>
+      <p class="mt-2">
+        Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne
+        konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden
+        von Rechtsverletzungen werden wir derartige Links umgehend entfernen.
+      </p>
+
+      <!-- Copyright -->
+      <h3 class="section-heading pb-2 pt-6 text-xl leading-8 tracking-tight font-semibold">
+        Urheberrecht
+      </h3>
+      <p>
+        Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten
+        unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung,
+        Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes
+        bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers.
+        Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen
+        Gebrauch gestattet.
+      </p>
+      <p class="mt-2">
+        Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden
+        die Urheberrechte Dritter beachtet. Insbesondere werden Inhalte Dritter als
+        solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung
+        aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden
+        von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.
       </p>
     </main>
   </div>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,258 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+---
+
+<Layout title="Privacy Policy - Agentic Hamburg">
+  <Header />
+
+  <div class="privacy-container flex min-h-screen flex-col">
+    <main class="mx-auto max-w-4xl flex-grow px-4 py-12">
+      <h1
+        class="md:leading-14 text-3xl font-extrabold leading-9 tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-6xl"
+      >
+        Privacy Policy
+      </h1>
+
+      <p class="mt-6 text-gray-600">Last updated: January 2026</p>
+
+      <!-- Introduction -->
+      <div class="mt-6">
+        <p>
+          We take your privacy seriously. This privacy policy explains how Korfmann Ventures UG
+          (haftungsbeschränkt) ("we", "us", "our") collects, uses, and protects your personal
+          data when you use our website and services related to Agentic Conf Hamburg and
+          Agentic Hamburg meetups.
+        </p>
+      </div>
+
+      <!-- Data Controller -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        1. Data Controller
+      </h2>
+      <p>
+        The data controller responsible for your personal data is:
+      </p>
+      <p class="mt-4">
+        Korfmann Ventures UG (haftungsbeschränkt)<br />
+        Parkallee 7<br />
+        20144 Hamburg<br />
+        Germany<br />
+        Email: <a href="mailto:hello@agentic.hamburg" class="text-blue-600 hover:underline">hello@agentic.hamburg</a>
+      </p>
+
+      <!-- Data Collection -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        2. Data We Collect
+      </h2>
+      <p>We collect data through the following means:</p>
+
+      <h3 class="pb-2 pt-4 text-xl font-semibold">Website Visits</h3>
+      <p>
+        When you visit our website, our hosting provider (Netlify) automatically collects
+        server logs including your IP address, browser type, and pages visited. This data
+        is used for security and performance purposes.
+      </p>
+
+      <h3 class="pb-2 pt-4 text-xl font-semibold">Newsletter Subscription</h3>
+      <p>
+        If you subscribe to our newsletter, we collect your email address. This data is
+        processed by ConvertKit, our email marketing service provider.
+      </p>
+
+      <h3 class="pb-2 pt-4 text-xl font-semibold">Event Registration</h3>
+      <p>
+        When you register for our events through Luma, they collect your name, email address,
+        and any additional information you provide. If you purchase a ticket, payment is
+        processed by Stripe through Luma's platform.
+      </p>
+
+      <h3 class="pb-2 pt-4 text-xl font-semibold">Analytics</h3>
+      <p>
+        We use PostHog for analytics to understand how visitors use our website. PostHog
+        collects anonymized usage data including page views, clicks, and session information.
+      </p>
+
+      <!-- Third-Party Services -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        3. Third-Party Services
+      </h2>
+      <p>We use the following third-party services that may process your data:</p>
+
+      <h3 class="pb-2 pt-4 text-xl font-semibold">Netlify (Hosting)</h3>
+      <p>
+        Our website is hosted on Netlify. Netlify processes server logs and may use cookies
+        for performance optimization.
+        <a
+          href="https://www.netlify.com/privacy/"
+          class="text-blue-600 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer">Netlify Privacy Policy</a
+        >
+      </p>
+
+      <h3 class="pb-2 pt-4 text-xl font-semibold">ConvertKit (Newsletter)</h3>
+      <p>
+        We use ConvertKit to manage our newsletter subscriptions and send email communications.
+        <a
+          href="https://convertkit.com/privacy"
+          class="text-blue-600 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer">ConvertKit Privacy Policy</a
+        >
+      </p>
+
+      <h3 class="pb-2 pt-4 text-xl font-semibold">Luma (Events & Ticketing)</h3>
+      <p>
+        We use Luma to manage event registrations and ticket sales. When you register for
+        an event or purchase a ticket, your data is processed by Luma.
+        <a
+          href="https://lu.ma/privacy"
+          class="text-blue-600 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer">Luma Privacy Policy</a
+        >
+      </p>
+
+      <h3 class="pb-2 pt-4 text-xl font-semibold">Stripe (Payments)</h3>
+      <p>
+        Payment processing for ticket purchases is handled by Stripe through the Luma platform.
+        <a
+          href="https://stripe.com/privacy"
+          class="text-blue-600 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer">Stripe Privacy Policy</a
+        >
+      </p>
+
+      <h3 class="pb-2 pt-4 text-xl font-semibold">PostHog (Analytics)</h3>
+      <p>
+        We use PostHog for website analytics to improve our services.
+        <a
+          href="https://posthog.com/privacy"
+          class="text-blue-600 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer">PostHog Privacy Policy</a
+        >
+      </p>
+
+      <!-- Legal Basis -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        4. Legal Basis for Processing
+      </h2>
+      <p>We process your personal data based on the following legal grounds:</p>
+      <ul class="mt-2 list-disc pl-6">
+        <li><strong>Contract:</strong> Processing necessary for event registration and ticket purchases</li>
+        <li><strong>Consent:</strong> Newsletter subscriptions (you can withdraw consent at any time)</li>
+        <li><strong>Legitimate Interest:</strong> Website analytics and security</li>
+      </ul>
+
+      <!-- Data Retention -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        5. Data Retention
+      </h2>
+      <p>
+        We retain your personal data only for as long as necessary to fulfill the purposes
+        for which it was collected:
+      </p>
+      <ul class="mt-2 list-disc pl-6">
+        <li>Newsletter subscriptions: Until you unsubscribe</li>
+        <li>Event registration data: For the duration required by tax and accounting laws (typically 10 years in Germany)</li>
+        <li>Analytics data: Anonymized and aggregated, retained indefinitely</li>
+      </ul>
+
+      <!-- Your Rights -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        6. Your Rights Under GDPR
+      </h2>
+      <p>Under the General Data Protection Regulation (GDPR), you have the following rights:</p>
+      <ul class="mt-2 list-disc pl-6">
+        <li><strong>Right of Access:</strong> Request a copy of your personal data</li>
+        <li><strong>Right to Rectification:</strong> Request correction of inaccurate data</li>
+        <li><strong>Right to Erasure:</strong> Request deletion of your personal data</li>
+        <li><strong>Right to Restrict Processing:</strong> Request limitation of data processing</li>
+        <li><strong>Right to Data Portability:</strong> Request transfer of your data</li>
+        <li><strong>Right to Object:</strong> Object to processing based on legitimate interests</li>
+        <li><strong>Right to Withdraw Consent:</strong> Withdraw consent at any time</li>
+      </ul>
+      <p class="mt-4">
+        To exercise any of these rights, please contact us at <a href="mailto:hello@agentic.hamburg" class="text-blue-600 hover:underline">hello@agentic.hamburg</a>.
+      </p>
+
+      <!-- Cookies -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        7. Cookies
+      </h2>
+      <p>
+        Our website uses cookies for analytics and functionality. You can control cookie
+        settings in your browser. Essential cookies are necessary for the website to function
+        and cannot be disabled.
+      </p>
+
+      <!-- Data Security -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        8. Data Security
+      </h2>
+      <p>
+        We implement appropriate technical and organizational measures to protect your
+        personal data against unauthorized access, alteration, disclosure, or destruction.
+        Our website uses HTTPS encryption for all data transmission.
+      </p>
+
+      <!-- International Transfers -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        9. International Data Transfers
+      </h2>
+      <p>
+        Some of our third-party service providers are located outside the European Economic
+        Area (EEA). We ensure appropriate safeguards are in place, such as Standard
+        Contractual Clauses, before transferring data to these providers.
+      </p>
+
+      <!-- Supervisory Authority -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        10. Right to Lodge a Complaint
+      </h2>
+      <p>
+        You have the right to lodge a complaint with a supervisory authority if you believe
+        your data protection rights have been violated. The competent supervisory authority
+        in Hamburg is:
+      </p>
+      <p class="mt-4">
+        Der Hamburgische Beauftragte für Datenschutz und Informationsfreiheit<br />
+        Ludwig-Erhard-Str. 22, 7. OG<br />
+        20459 Hamburg<br />
+        <a
+          href="https://datenschutz-hamburg.de"
+          class="text-blue-600 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer">https://datenschutz-hamburg.de</a
+        >
+      </p>
+
+      <!-- Changes -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        11. Changes to This Policy
+      </h2>
+      <p>
+        We may update this privacy policy from time to time. Any changes will be posted
+        on this page with an updated revision date.
+      </p>
+
+      <!-- Contact -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        12. Contact Us
+      </h2>
+      <p>
+        If you have any questions about this privacy policy or our data practices, please
+        contact us at:
+      </p>
+      <p class="mt-4">
+        Email: <a href="mailto:hello@agentic.hamburg" class="text-blue-600 hover:underline">hello@agentic.hamburg</a>
+      </p>
+    </main>
+  </div>
+
+  <Footer />
+</Layout>

--- a/src/pages/tos.astro
+++ b/src/pages/tos.astro
@@ -1,0 +1,226 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+---
+
+<Layout title="Terms of Service - Agentic Hamburg">
+  <Header />
+
+  <div class="tos-container flex min-h-screen flex-col">
+    <main class="mx-auto max-w-4xl flex-grow px-4 py-12">
+      <h1
+        class="md:leading-14 text-3xl font-extrabold leading-9 tracking-tight text-gray-900 sm:text-4xl sm:leading-10 md:text-6xl"
+      >
+        Terms of Service
+      </h1>
+
+      <p class="mt-6 text-gray-600">Last updated: January 2026</p>
+
+      <!-- Introduction -->
+      <div class="mt-6">
+        <p>
+          These Terms of Service ("Terms") govern your participation in Agentic Conf Hamburg
+          and related events organized by Korfmann Ventures UG (haftungsbeschränkt) ("we",
+          "us", "our"). By purchasing a ticket or attending our events, you agree to these Terms.
+        </p>
+      </div>
+
+      <!-- Organizer -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        1. Event Organizer
+      </h2>
+      <p>
+        Agentic Conf Hamburg is organized by:
+      </p>
+      <p class="mt-4">
+        Korfmann Ventures UG (haftungsbeschränkt)<br />
+        Parkallee 7<br />
+        20144 Hamburg<br />
+        Germany<br />
+        Email: <a href="mailto:hello@agentic.hamburg" class="text-blue-600 hover:underline">hello@agentic.hamburg</a>
+      </p>
+
+      <!-- Ticket Purchase -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        2. Ticket Purchase
+      </h2>
+      <p>
+        Tickets for our events are sold through Luma (lu.ma). By purchasing a ticket, you
+        enter into a contract with Korfmann Ventures UG for attendance at the specified event.
+      </p>
+      <p class="mt-4">
+        Payment is processed by Stripe through the Luma platform. All prices include
+        applicable taxes unless otherwise stated. You will receive a confirmation email
+        with your ticket details after purchase.
+      </p>
+
+      <!-- Refund Policy -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        3. Refund Policy
+      </h2>
+      <p>
+        <strong>Tickets are non-refundable.</strong> Once a ticket is purchased, we cannot
+        offer refunds except in the following circumstances:
+      </p>
+      <ul class="mt-2 list-disc pl-6">
+        <li>Event cancellation by the organizer</li>
+        <li>Significant change to the event date or location</li>
+      </ul>
+      <p class="mt-4">
+        In case of event cancellation by the organizer, we will offer a full refund or
+        credit toward a future event at your choice.
+      </p>
+
+      <!-- Ticket Transfers -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        4. Ticket Transfers
+      </h2>
+      <p>
+        <strong>Tickets are transferable.</strong> If you cannot attend, you may transfer
+        your ticket to another person. Please contact us at <a href="mailto:hello@agentic.hamburg" class="text-blue-600 hover:underline">hello@agentic.hamburg</a>
+        to arrange the transfer, or use the transfer feature in Luma if available.
+      </p>
+
+      <!-- Code of Conduct -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        5. Code of Conduct
+      </h2>
+      <p>
+        All attendees, speakers, sponsors, and volunteers at our events are required to
+        agree with and follow the <a
+          href="https://berlincodeofconduct.org/"
+          class="text-blue-600 hover:underline"
+          target="_blank"
+          rel="noopener noreferrer">Berlin Code of Conduct</a
+        >.
+      </p>
+      <p class="mt-4">
+        We are dedicated to providing a harassment-free experience for everyone, regardless
+        of gender, gender identity and expression, age, sexual orientation, disability,
+        physical appearance, body size, race, ethnicity, religion, or technology choices.
+      </p>
+      <p class="mt-4">
+        We do not tolerate harassment of participants in any form. Participants violating
+        these rules may be sanctioned or expelled from the event without a refund at the
+        discretion of the organizers.
+      </p>
+
+      <!-- Photography and Video -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        6. Photography and Video
+      </h2>
+      <p>
+        By attending our events, you consent to being photographed and recorded. These
+        images and recordings may be used for promotional purposes, including social media,
+        website, and marketing materials.
+      </p>
+      <p class="mt-4">
+        If you do not wish to be photographed or recorded, please notify us at
+        <a href="mailto:hello@agentic.hamburg" class="text-blue-600 hover:underline">hello@agentic.hamburg</a> before the event, and we will do our best
+        to accommodate your request.
+      </p>
+
+      <!-- Liability -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        7. Liability
+      </h2>
+      <p>
+        Attendance at our events is at your own risk. We are not liable for any personal
+        injury, loss, or damage to property that may occur during the event, except where
+        caused by our gross negligence or willful misconduct.
+      </p>
+      <p class="mt-4">
+        We are not responsible for the content of presentations or materials provided by
+        speakers or sponsors. Views expressed by speakers do not necessarily reflect the
+        views of Korfmann Ventures UG.
+      </p>
+
+      <!-- Force Majeure -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        8. Force Majeure
+      </h2>
+      <p>
+        We shall not be liable for any failure or delay in performing our obligations
+        where such failure or delay results from circumstances beyond our reasonable control,
+        including but not limited to:
+      </p>
+      <ul class="mt-2 list-disc pl-6">
+        <li>Natural disasters, extreme weather conditions</li>
+        <li>War, terrorism, civil unrest</li>
+        <li>Pandemic or public health emergency</li>
+        <li>Government actions or regulations</li>
+        <li>Venue unavailability</li>
+        <li>Strike or labor disputes</li>
+      </ul>
+      <p class="mt-4">
+        In such cases, we will make reasonable efforts to reschedule the event or provide
+        alternative arrangements. If the event cannot be rescheduled, we will offer refunds
+        or credits at our discretion.
+      </p>
+
+      <!-- Program Changes -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        9. Program Changes
+      </h2>
+      <p>
+        We reserve the right to make changes to the event program, including speakers,
+        schedule, and venue, at any time. We will make reasonable efforts to notify
+        attendees of significant changes in advance.
+      </p>
+
+      <!-- Intellectual Property -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        10. Intellectual Property
+      </h2>
+      <p>
+        All content provided at our events, including presentations, materials, and
+        recordings, is protected by intellectual property rights. You may not reproduce,
+        distribute, or create derivative works from this content without explicit
+        permission from the respective rights holders.
+      </p>
+
+      <!-- Governing Law -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        11. Governing Law
+      </h2>
+      <p>
+        These Terms are governed by and construed in accordance with the laws of the
+        Federal Republic of Germany. Any disputes arising from these Terms shall be
+        subject to the exclusive jurisdiction of the courts of Hamburg, Germany.
+      </p>
+
+      <!-- Severability -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        12. Severability
+      </h2>
+      <p>
+        If any provision of these Terms is found to be invalid or unenforceable, the
+        remaining provisions shall continue in full force and effect.
+      </p>
+
+      <!-- Changes to Terms -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        13. Changes to These Terms
+      </h2>
+      <p>
+        We may update these Terms from time to time. Any changes will be posted on this
+        page with an updated revision date. Continued use of our services after changes
+        constitutes acceptance of the new Terms.
+      </p>
+
+      <!-- Contact -->
+      <h2 class="pb-2 pt-8 text-2xl font-semibold leading-8 tracking-tight">
+        14. Contact Us
+      </h2>
+      <p>
+        If you have any questions about these Terms, please contact us at:
+      </p>
+      <p class="mt-4">
+        Email: <a href="mailto:hello@agentic.hamburg" class="text-blue-600 hover:underline">hello@agentic.hamburg</a>
+      </p>
+    </main>
+  </div>
+
+  <Footer />
+</Layout>


### PR DESCRIPTION
## Summary
- Add privacy policy page (`/privacy`)
- Add terms of service page (`/tos`)
- Update imprint with correct Korfmann Ventures UG company information
- Unify all contact emails to `hello@agentic.hamburg` across the website

## Test plan
- [ ] Verify `/privacy` page loads correctly
- [ ] Verify `/tos` page loads correctly
- [ ] Verify `/imprint` page shows updated company info
- [ ] Confirm all email links use `hello@agentic.hamburg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)