### PR TITLE
feat: add conference banner for Agentic Conf Hamburg 2026

### DIFF
--- a/src/components/ConferenceBanner.astro
+++ b/src/components/ConferenceBanner.astro
@@ -1,0 +1,109 @@
+---
+// Conference announcement banner for Agentic Conf Hamburg 2026
+---
+
+<a
+  href="https://lu.ma/45lfeyeh"
+  target="_blank"
+  rel="noopener noreferrer"
+  class="conference-banner"
+>
+  <div class="banner-content">
+    <span class="banner-badge">NEW</span>
+    <span class="banner-text">
+      <strong>Agentic Conf Hamburg 2026</strong> — March 22, 2026 • Full day conference on Agentic Software Engineering
+    </span>
+    <span class="banner-cta">
+      Get Tickets
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M5 12h14"></path>
+        <path d="m12 5 7 7-7 7"></path>
+      </svg>
+    </span>
+  </div>
+</a>
+
+<style>
+  .conference-banner {
+    display: block;
+    background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-accent) 100%);
+    color: white;
+    text-decoration: none;
+    padding: 0.75rem 1rem;
+    text-align: center;
+    font-weight: 500;
+    transition: all 0.3s ease;
+  }
+
+  .conference-banner:hover {
+    filter: brightness(1.05);
+  }
+
+  .banner-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  .banner-badge {
+    background: rgba(255, 255, 255, 0.2);
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+
+  .banner-text {
+    font-size: 0.95rem;
+  }
+
+  .banner-text strong {
+    font-weight: 700;
+  }
+
+  .banner-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: rgba(255, 255, 255, 0.2);
+    padding: 0.35rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    transition: background 0.2s ease;
+  }
+
+  .conference-banner:hover .banner-cta {
+    background: rgba(255, 255, 255, 0.3);
+  }
+
+  @media (max-width: 640px) {
+    .banner-content {
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .banner-text {
+      font-size: 0.875rem;
+    }
+
+    .banner-badge {
+      display: none;
+    }
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import Footer from "../components/Footer.astro";
 import EventCards from "../components/EventCards.astro";
 import SocialProof from "../components/SocialProof.astro";
 import PastEvents from "../components/PastEvents.astro";
+import ConferenceBanner from "../components/ConferenceBanner.astro";
 import { useTranslations } from "../lib/i18n/utils";
 
 const t = useTranslations();
@@ -14,6 +15,7 @@ const t = useTranslations();
 
 <Layout title="Agentic Hamburg - The Coding Meetup for Hamburg">
   <Header />
+  <ConferenceBanner />
 
   <main>
     <!-- Hero Section -->


### PR DESCRIPTION
## Summary
- Add a prominent announcement banner at the top of the homepage for Agentic Conf Hamburg 2026
- Banner includes event date (March 22, 2026) and "Get Tickets" CTA linking to Luma
- Responsive design with orange gradient matching site theme

## Test plan
- [ ] Verify banner displays correctly on desktop
- [ ] Verify banner displays correctly on mobile
- [ ] Verify "Get Tickets" link opens Luma event page in new tab

🤖 Generated with [Claude Code](https://claude.ai/code)