### PR TITLE
Add Local Conference Partner Network to conf page

### DIFF
--- a/src/pages/conf-2026.astro
+++ b/src/pages/conf-2026.astro
@@ -106,6 +106,27 @@ const speakers = [
   },
 ];
 
+const partnerConferences = [
+  {
+    name: "reher*sal",
+    date: "Feb 6, 2026",
+    description: "Non-profit conference empowering FLINTA* speakers in tech to become more visible on stage.",
+    url: "https://rehersal.io/",
+  },
+  {
+    name: "Social Developers Conference",
+    date: "Mar 21, 2026",
+    description: "Community conference making technology accessible to all and driving positive social impact.",
+    url: "https://socialdevelopersclub.de/",
+  },
+  {
+    name: "code.talks",
+    date: "Nov 4–5, 2026",
+    description: "Germany's largest developer conference — 3,500+ devs, 100+ sessions, at KINOPOLIS HafenCity.",
+    url: "https://codetalks.com/",
+  },
+];
+
 const faqs = [
   {
     question: "When and where is the conference?",
@@ -491,6 +512,32 @@ const faqs = [
         <p class="faq-contact">
           Still have questions? Email us at <a href="mailto:hello@agentic.hamburg">hello@agentic.hamburg</a>
         </p>
+      </div>
+    </section>
+
+    <!-- Local Conference Partner Network -->
+    <section class="conf-section conf-partners">
+      <div class="mx-auto max-w-4xl px-4">
+        <p class="section-label">Hamburg Tech Scene</p>
+        <h2 class="section-title">Local Conference Partner Network</h2>
+        <p class="section-description">
+          Conferences we're proud to stand alongside — Hamburg's tech community is vibrant.
+        </p>
+        <div class="partners-grid">
+          {partnerConferences.map(conf => (
+            <a href={conf.url} target="_blank" rel="noopener noreferrer" class="partner-card">
+              <div class="partner-date">{conf.date}</div>
+              <h3 class="partner-name">{conf.name}</h3>
+              <p class="partner-description">{conf.description}</p>
+              <span class="partner-link-text">
+                Learn more
+                <svg class="partner-arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                </svg>
+              </span>
+            </a>
+          ))}
+        </div>
       </div>
     </section>
   </main>
@@ -1254,5 +1301,83 @@ const faqs = [
       height: 24px;
       max-width: 110px;
     }
+  }
+
+  /* Partner Network Section */
+  .partners-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  @media (max-width: 768px) {
+    .partners-grid {
+      grid-template-columns: 1fr;
+      max-width: 400px;
+    }
+  }
+
+  .partner-card {
+    display: flex;
+    flex-direction: column;
+    background: white;
+    padding: 1.75rem;
+    border-radius: 16px;
+    border: 1px solid rgba(44, 62, 58, 0.08);
+    text-decoration: none;
+    color: inherit;
+    transition: all 0.3s ease;
+  }
+
+  .partner-card:hover {
+    border-color: var(--color-primary);
+    box-shadow: 0 4px 20px rgba(232, 136, 127, 0.12);
+    transform: translateY(-2px);
+  }
+
+  .partner-date {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-primary);
+    margin-bottom: 0.5rem;
+  }
+
+  .partner-name {
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: var(--color-text-primary);
+    margin-bottom: 0.75rem;
+    line-height: 1.3;
+  }
+
+  .partner-description {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--color-text-secondary);
+    flex-grow: 1;
+    margin-bottom: 1rem;
+  }
+
+  .partner-link-text {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    transition: gap 0.3s ease;
+  }
+
+  .partner-card:hover .partner-link-text {
+    gap: 0.5rem;
+  }
+
+  .partner-arrow {
+    width: 1rem;
+    height: 1rem;
   }
 </style>


### PR DESCRIPTION
## Summary
- Add "Local Conference Partner Network" section to the conference page (after FAQ, before footer)
- Features three Hamburg tech conferences: reher*sal, Social Developers Conference, and code.talks
- Responsive 3-column card grid (stacks to single column on mobile) with hover animations

## Test plan
- [ ] Verify section renders correctly on desktop (3-column layout)
- [ ] Verify responsive layout on mobile (single column)
- [ ] Verify all three conference links open correct external URLs
- [ ] Run `npm run build` to confirm no type/build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)