### PR TITLE
Replace ticket CTAs with sold-out badges and newsletter signup

### DIFF
--- a/src/components/ConferenceBanner.astro
+++ b/src/components/ConferenceBanner.astro
@@ -3,19 +3,17 @@
 ---
 
 <a
-  href="https://lu.ma/45lfeyeh"
-  target="_blank"
-  rel="noopener noreferrer"
+  href="/conf-2026/"
   class="conference-banner"
 >
   <div class="banner-content">
-    <span class="banner-badge">NEW</span>
+    <span class="banner-badge">SOLD OUT</span>
     <span class="banner-text">
       <strong>Agentic Conf Hamburg 2026</strong> — March 22, 2026 • Full day conference
       on Agentic Software Engineering
     </span>
     <span class="banner-cta">
-      Get Tickets
+      View Program
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="16"

--- a/src/pages/conf-2026/index.astro
+++ b/src/pages/conf-2026/index.astro
@@ -356,13 +356,9 @@ const faqs = [
         </p>
 
         <div class="hero-ctas">
-          <a
-            href={ticketUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="cta-primary"
-          >
-            Get Tickets
+          <span class="sold-out-badge">Sold Out</span>
+          <a href="#newsletter" class="cta-secondary">
+            Get Updates
             <svg
               class="cta-arrow"
               fill="none"
@@ -673,34 +669,45 @@ const faqs = [
       </div>
     </section>
 
-    <!-- Tickets Section -->
-    <section class="conf-section conf-tickets">
+    <!-- Newsletter Section -->
+    <section id="newsletter" class="conf-section conf-tickets">
       <div class="mx-auto max-w-4xl px-4 text-center">
-        <p class="section-label">Join Us</p>
-        <h2 class="section-title">Get Your Ticket</h2>
+        <p class="section-label">Sold Out</p>
+        <h2 class="section-title">Stay in the Loop</h2>
         <p class="section-description">
-          Secure your spot at Hamburg's first agentic coding conference.
+          Tickets are sold out! Subscribe to get updates on waitlist openings,
+          recordings, and future events.
         </p>
-        <a
-          href={ticketUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="cta-primary cta-large"
+        <form
+          id="conf-newsletter-form"
+          action="/api/subscribe"
+          method="post"
+          class="conf-newsletter-form"
         >
-          Get Tickets on Luma
-          <svg
-            class="cta-icon"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
-          </svg>
-        </a>
+          <div class="conf-newsletter-inputs">
+            <input
+              type="email"
+              name="email"
+              placeholder="Enter your email address"
+              required
+              class="conf-newsletter-email"
+              aria-label="Email address"
+            />
+            <button type="submit" class="conf-newsletter-button">
+              <span class="button-text">Subscribe</span>
+              <span class="button-loading" aria-hidden="true"
+                >Subscribing...</span
+              >
+            </button>
+          </div>
+        </form>
+        <div
+          id="conf-form-message"
+          class="conf-form-message hidden"
+          role="alert"
+          aria-live="polite"
+        >
+        </div>
       </div>
     </section>
 
@@ -1226,8 +1233,44 @@ const faqs = [
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    align-items: center;
     gap: 1rem;
     margin-bottom: 3rem;
+  }
+
+  .sold-out-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 1rem 2rem;
+    background: var(--color-text-secondary);
+    color: white;
+    border-radius: 8px;
+    font-weight: 700;
+    font-size: 1.125rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+  }
+
+  .cta-secondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: transparent;
+    color: var(--color-primary);
+    padding: 1rem 2rem;
+    border-radius: 8px;
+    font-weight: 700;
+    font-size: 1.125rem;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    border: 2px solid var(--color-primary);
+  }
+
+  .cta-secondary:hover {
+    background: var(--color-primary);
+    color: white;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(247, 127, 0, 0.4);
   }
 
   .cta-arrow {
@@ -1429,7 +1472,7 @@ const faqs = [
     font-weight: 600;
   }
 
-  /* Tickets Section */
+  /* Newsletter / Sold Out Section */
   .conf-tickets {
     background: linear-gradient(
       135deg,
@@ -1444,20 +1487,96 @@ const faqs = [
     color: white;
   }
 
-  .cta-large {
-    font-size: 1.25rem;
-    padding: 1.25rem 2.5rem;
+  .conf-newsletter-form {
+    max-width: 500px;
+    margin: 0 auto;
   }
 
-  .conf-tickets .cta-primary {
+  .conf-newsletter-inputs {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .conf-newsletter-email {
+    flex: 1;
+    padding: 0.875rem 1.25rem;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.15);
+    color: white;
+    font-size: 1rem;
+    font-family: inherit;
+    outline: none;
+    transition: border-color 0.2s ease;
+  }
+
+  .conf-newsletter-email::placeholder {
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .conf-newsletter-email:focus {
+    border-color: white;
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .conf-newsletter-button {
+    position: relative;
+    padding: 0.875rem 2rem;
     background: white;
     color: var(--color-primary);
-    border-color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 700;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    white-space: nowrap;
   }
 
-  .conf-tickets .cta-primary:hover {
+  .conf-newsletter-button:hover {
     background: var(--color-bg-light);
-    border-color: var(--color-bg-light);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  .conf-newsletter-button .button-text {
+    display: inline;
+  }
+
+  .conf-newsletter-button .button-loading {
+    display: none;
+  }
+
+  .conf-newsletter-button.form-loading .button-text {
+    display: none;
+  }
+
+  .conf-newsletter-button.form-loading .button-loading {
+    display: inline;
+  }
+
+  .conf-form-message {
+    margin-top: 0.75rem;
+    font-size: 0.95rem;
+  }
+
+  .conf-form-message.message-success {
+    color: #d4ffd4;
+  }
+
+  .conf-form-message.message-error {
+    color: #ffd4d4;
+  }
+
+  .hidden {
+    display: none;
+  }
+
+  @media (max-width: 480px) {
+    .conf-newsletter-inputs {
+      flex-direction: column;
+    }
   }
 
   /* Organizers Section */
@@ -1865,3 +1984,65 @@ const faqs = [
     height: 1rem;
   }
 </style>
+
+<script>
+  function initConfNewsletter() {
+    const form = document.getElementById(
+      "conf-newsletter-form"
+    ) as HTMLFormElement | null;
+    const messageDiv = document.getElementById(
+      "conf-form-message"
+    ) as HTMLDivElement | null;
+
+    if (!form || !messageDiv) return;
+
+    const submitButton = form.querySelector(
+      'button[type="submit"]'
+    ) as HTMLButtonElement;
+
+    form.addEventListener("submit", async (e: Event) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      messageDiv.classList.add("hidden");
+      messageDiv.classList.remove("message-success", "message-error");
+
+      submitButton.classList.add("form-loading");
+      submitButton.disabled = true;
+
+      try {
+        const formData = new FormData(form);
+        const response = await fetch("/api/subscribe", {
+          method: "POST",
+          body: formData,
+        });
+
+        const result = await response.json();
+
+        if (response.ok) {
+          messageDiv.textContent =
+            result.message || "Successfully subscribed!";
+          messageDiv.classList.add("message-success");
+          messageDiv.classList.remove("hidden");
+          form.reset();
+        } else {
+          messageDiv.textContent =
+            result.error || "Something went wrong. Please try again.";
+          messageDiv.classList.add("message-error");
+          messageDiv.classList.remove("hidden");
+        }
+      } catch {
+        messageDiv.textContent =
+          "Network error. Please check your connection and try again.";
+        messageDiv.classList.add("message-error");
+        messageDiv.classList.remove("hidden");
+      } finally {
+        submitButton.classList.remove("form-loading");
+        submitButton.disabled = false;
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", initConfNewsletter);
+  document.addEventListener("astro:page-load", initConfNewsletter);
+</script>

--- a/src/pages/conf-2026/sessions/[slug].astro
+++ b/src/pages/conf-2026/sessions/[slug].astro
@@ -114,8 +114,11 @@ const paragraphs = session.description.split("\n\n").filter(Boolean);
             </dl>
           </div>
 
-          <a href="https://lu.ma/45lfeyeh" class="ticket-cta">
-            Get Your Ticket
+          <div class="ticket-sold-out">
+            <span class="sold-out-text">Sold Out</span>
+          </div>
+          <a href="/conf-2026/#newsletter" class="ticket-cta ticket-cta--newsletter">
+            Get Updates
             <svg
               width="16"
               height="16"
@@ -310,6 +313,25 @@ const paragraphs = session.description.split("\n\n").filter(Boolean);
     color: var(--color-text-primary);
     font-weight: 600;
     margin: 0;
+  }
+
+  .ticket-sold-out {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 0.875rem 1.5rem;
+    background: var(--color-text-secondary);
+    border-radius: 12px;
+    margin-bottom: 0.5rem;
+  }
+
+  .sold-out-text {
+    color: white;
+    font-weight: 700;
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
   }
 
   .ticket-cta {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ import { communityStats } from "../config/community";
     <div class="banner-content">
       <span class="banner-badge">March 22, 2026</span>
       <span class="banner-text"
-        >Agentic Conf Hamburg — Tickets now available</span
+        >Agentic Conf Hamburg — Sold Out</span
       >
       <svg
         class="banner-arrow"
@@ -92,9 +92,8 @@ import { communityStats } from "../config/community";
           <article class="activity-card card-conference">
             <div class="card-glow"></div>
             <div class="card-content">
-              <div class="card-badge">
-                <span class="badge-live"></span>
-                Tickets Available
+              <div class="card-badge badge-sold-out">
+                Sold Out
               </div>
 
               <div class="card-date">
@@ -135,13 +134,8 @@ import { communityStats } from "../config/community";
               </div>
 
               <div class="card-actions">
-                <a
-                  href="https://lu.ma/45lfeyeh"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="btn-primary"
-                >
-                  <span>Get Tickets</span>
+                <a href="/conf-2026" class="btn-primary">
+                  <span>View Program</span>
                   <svg
                     viewBox="0 0 24 24"
                     fill="none"
@@ -151,7 +145,6 @@ import { communityStats } from "../config/community";
                     <path d="M5 12h14M12 5l7 7-7 7"></path>
                   </svg>
                 </a>
-                <a href="/conf-2026" class="btn-ghost"> Learn more </a>
               </div>
             </div>
           </article>
@@ -299,17 +292,12 @@ import { communityStats } from "../config/community";
         <div class="cta-content">
           <h2 class="cta-title">Ready to Build?</h2>
           <p class="cta-text">
-            Join Hamburg's most active AI agent community. Conference tickets
-            are limited.
+            Join Hamburg's most active AI agent community. Subscribe for
+            updates on waitlist, recordings, and future events.
           </p>
           <div class="cta-actions">
-            <a
-              href="https://lu.ma/45lfeyeh"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="btn-cta"
-            >
-              <span>Get Conference Tickets</span>
+            <a href="/conf-2026/#newsletter" class="btn-cta">
+              <span>Subscribe for Updates</span>
               <svg
                 viewBox="0 0 24 24"
                 fill="none"
@@ -674,6 +662,11 @@ import { communityStats } from "../config/community";
     padding: 0.5rem 1rem;
     border-radius: 50px;
     margin-bottom: 1.25rem;
+  }
+
+  .badge-sold-out {
+    background: rgba(44, 62, 58, 0.15);
+    color: var(--color-text-secondary);
   }
 
   .badge-live {

--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -16,7 +16,7 @@ import PastEvents from "../components/PastEvents.astro";
     <div class="banner-content">
       <span class="banner-badge">March 22, 2026</span>
       <span class="banner-text"
-        >Agentic Conf Hamburg — Tickets now available</span
+        >Agentic Conf Hamburg — Sold Out</span
       >
       <svg
         class="banner-arrow"


### PR DESCRIPTION
## Summary
- Replace all "Get Tickets" CTAs across the site with "Sold Out" badges
- Add newsletter signup form on conference page for waitlist/recording/future event updates (uses existing ConvertKit `/api/subscribe` endpoint)
- Update homepage banner, conference card, bottom CTA, meetups banner, session detail pages, and ConferenceBanner component

## Test plan
- [ ] Verify conference page hero shows "Sold Out" badge + "Get Updates" link
- [ ] Verify newsletter section renders with email input and subscribe button
- [ ] Test newsletter form submission works (ConvertKit integration)
- [ ] Verify session detail pages show "Sold Out" + "Get Updates" in sidebar
- [ ] Verify homepage banner, conference card, and bottom CTA are updated
- [ ] Verify meetups page banner is updated
- [ ] Check mobile responsiveness of newsletter form

🤖 Generated with [Claude Code](https://claude.com/claude-code)