### PR TITLE
Promote Meetup #5, demote past conference

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,12 +8,17 @@ import { communityStats } from "../config/community";
 <Layout title="Agentic Hamburg - Community for AI Agent Builders">
   <Header />
 
-  <!-- Conference Banner -->
-  <a href="/conf-2026" class="conf-banner">
+  <!-- Next Meetup Banner -->
+  <a
+    href="https://luma.com/agentic-a7oi"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="conf-banner"
+  >
     <div class="banner-content">
-      <span class="banner-badge">March 22, 2026</span>
+      <span class="banner-badge">June 9, 2026</span>
       <span class="banner-text"
-        >Agentic Conf Hamburg — Sold Out</span
+        >Agentic Coding Meetup #5 @ MOIA — Join the Waitlist</span
       >
       <svg
         class="banner-arrow"
@@ -88,13 +93,11 @@ import { communityStats } from "../config/community";
         </div>
 
         <div class="activities-grid">
-          <!-- Conference Card -->
-          <article class="activity-card card-conference">
+          <!-- Next Meetup Card -->
+          <article class="activity-card card-featured">
             <div class="card-glow"></div>
             <div class="card-content">
-              <div class="card-badge badge-sold-out">
-                Sold Out
-              </div>
+              <div class="card-badge">Upcoming</div>
 
               <div class="card-date">
                 <svg
@@ -107,16 +110,16 @@ import { communityStats } from "../config/community";
                   <rect x="3" y="4" width="18" height="18" rx="2"></rect>
                   <path d="M16 2v4M8 2v4M3 10h18"></path>
                 </svg>
-                March 22, 2026
+                June 9, 2026 · 18:00–22:00
               </div>
 
               <h3 class="card-title">
-                Agentic Conf<br />Hamburg 2026
+                Agentic Coding<br />Meetup #5
               </h3>
 
               <p class="card-description">
-                A full-day conference with talks, live demos, workshops, and
-                networking. The biggest agentic AI event in Northern Germany.
+                Talks, live demos, and networking with Hamburg's agentic coding
+                community — the next chapter after a sold-out conference.
               </p>
 
               <div class="card-venue">
@@ -130,12 +133,17 @@ import { communityStats } from "../config/community";
                   <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"></path>
                   <circle cx="12" cy="10" r="3"></circle>
                 </svg>
-                <span>Medienbunker · SAE Institute Hamburg</span>
+                <span>MOIA GmbH · Stadthausbrücke 8, Hamburg</span>
               </div>
 
               <div class="card-actions">
-                <a href="/conf-2026" class="btn-primary">
-                  <span>View Program</span>
+                <a
+                  href="https://luma.com/agentic-a7oi"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="btn-primary"
+                >
+                  <span>Join the Waitlist</span>
                   <svg
                     viewBox="0 0 24 24"
                     fill="none"
@@ -145,12 +153,13 @@ import { communityStats } from "../config/community";
                     <path d="M5 12h14M12 5l7 7-7 7"></path>
                   </svg>
                 </a>
+                <a href="/meetups" class="btn-ghost">All meetups →</a>
               </div>
             </div>
           </article>
 
-          <!-- Meetups Card -->
-          <article class="activity-card card-meetups">
+          <!-- Conference Archive Card -->
+          <article class="activity-card card-secondary">
             <div class="card-content">
               <div class="card-badge badge-muted">
                 <svg
@@ -164,36 +173,22 @@ import { communityStats } from "../config/community";
                     d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
                   ></path>
                 </svg>
-                Regular Events
+                Past Event · March 22, 2026
               </div>
 
               <h3 class="card-title card-title-small">
-                Agentic Coding<br />Meetup
+                Agentic Conf<br />Hamburg 2026
               </h3>
 
               <p class="card-description">
-                Regular meetups for talks, demos, and networking with Hamburg's
-                agentic coding community.
+                Our biggest event yet — a full day of talks, live demos, and
+                workshops on agentic software engineering. Relive the full
+                program and sessions.
               </p>
 
-              <div class="card-metrics">
-                <div class="metric">
-                  <span class="metric-value">{communityStats.meetupCount}</span>
-                  <span class="metric-label">events</span>
-                </div>
-                <div class="metric">
-                  <span class="metric-value">400+</span>
-                  <span class="metric-label">attendees</span>
-                </div>
-                <div class="metric">
-                  <span class="metric-value">78</span>
-                  <span class="metric-label">reviews</span>
-                </div>
-              </div>
-
               <div class="card-actions">
-                <a href="/meetups" class="btn-secondary">
-                  <span>View Meetups</span>
+                <a href="/conf-2026" class="btn-secondary">
+                  <span>View Program</span>
                   <svg
                     viewBox="0 0 24 24"
                     fill="none"
@@ -292,8 +287,8 @@ import { communityStats } from "../config/community";
         <div class="cta-content">
           <h2 class="cta-title">Ready to Build?</h2>
           <p class="cta-text">
-            Join Hamburg's most active AI agent community. Subscribe for
-            updates on waitlist, recordings, and future events.
+            Join Hamburg's most active AI agent community. Subscribe for updates
+            on waitlist, recordings, and future events.
           </p>
           <div class="cta-actions">
             <a href="/conf-2026/#newsletter" class="btn-cta">
@@ -606,7 +601,7 @@ import { communityStats } from "../config/community";
     transform: translateY(-8px);
   }
 
-  .card-conference {
+  .card-featured {
     background: linear-gradient(
       145deg,
       var(--color-bg-soft) 0%,
@@ -616,11 +611,11 @@ import { communityStats } from "../config/community";
     box-shadow: 0 4px 30px rgba(232, 136, 127, 0.12);
   }
 
-  .card-conference:hover {
+  .card-featured:hover {
     box-shadow: 0 20px 60px rgba(232, 136, 127, 0.25);
   }
 
-  .card-conference .card-glow {
+  .card-featured .card-glow {
     position: absolute;
     top: -50%;
     right: -50%;
@@ -634,12 +629,12 @@ import { communityStats } from "../config/community";
     pointer-events: none;
   }
 
-  .card-meetups {
+  .card-secondary {
     background: var(--color-bg-soft);
     border: 2px solid rgba(44, 62, 58, 0.08);
   }
 
-  .card-meetups:hover {
+  .card-secondary:hover {
     border-color: rgba(232, 136, 127, 0.3);
     box-shadow: 0 20px 50px rgba(0, 0, 0, 0.08);
   }
@@ -662,11 +657,6 @@ import { communityStats } from "../config/community";
     padding: 0.5rem 1rem;
     border-radius: 50px;
     margin-bottom: 1.25rem;
-  }
-
-  .badge-sold-out {
-    background: rgba(44, 62, 58, 0.15);
-    color: var(--color-text-secondary);
   }
 
   .badge-live {
@@ -751,36 +741,6 @@ import { communityStats } from "../config/community";
     height: 18px;
     color: var(--color-primary-dark);
     flex-shrink: 0;
-  }
-
-  .card-metrics {
-    display: flex;
-    gap: 1.5rem;
-    margin-bottom: 1.75rem;
-    padding: 1rem 0;
-    border-top: 1px solid rgba(44, 62, 58, 0.08);
-    border-bottom: 1px solid rgba(44, 62, 58, 0.08);
-  }
-
-  .metric {
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-  }
-
-  .metric-value {
-    font-family: var(--font-display);
-    font-size: 1.25rem;
-    font-weight: 400;
-    color: var(--color-text-primary);
-  }
-
-  .metric-label {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--color-text-secondary);
   }
 
   .card-actions {
@@ -1085,10 +1045,10 @@ import { communityStats } from "../config/community";
       animation: fadeInUp 0.6s ease-out backwards;
     }
 
-    .card-conference {
+    .card-featured {
       animation-delay: 0.1s;
     }
-    .card-meetups {
+    .card-secondary {
       animation-delay: 0.2s;
     }
 

--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -11,12 +11,17 @@ import PastEvents from "../components/PastEvents.astro";
 >
   <Header />
 
-  <!-- Conference Banner -->
-  <a href="/conf-2026" class="conf-banner">
+  <!-- Next Meetup Banner -->
+  <a
+    href="https://luma.com/agentic-a7oi"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="conf-banner"
+  >
     <div class="banner-content">
-      <span class="banner-badge">March 22, 2026</span>
+      <span class="banner-badge">June 9, 2026</span>
       <span class="banner-text"
-        >Agentic Conf Hamburg — Sold Out</span
+        >Agentic Coding Meetup #5 @ MOIA — Join the Waitlist</span
       >
       <svg
         class="banner-arrow"
@@ -53,6 +58,56 @@ import PastEvents from "../components/PastEvents.astro";
               ></path>
             </svg>
             Join us on Meetup.com
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Next Meetup Section -->
+    <section class="next-meetup">
+      <div class="mx-auto max-w-4xl px-4 py-12">
+        <div class="next-card">
+          <span class="next-badge">Next Up</span>
+          <h2 class="next-title">Agentic Coding Meetup #5</h2>
+          <div class="next-details">
+            <div class="next-detail">
+              <svg fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fill-rule="evenodd"
+                  d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+                  clip-rule="evenodd"></path>
+              </svg>
+              <span>Tuesday, June 9, 2026 · 18:00–22:00</span>
+            </div>
+            <div class="next-detail">
+              <svg fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fill-rule="evenodd"
+                  d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+                  clip-rule="evenodd"></path>
+              </svg>
+              <span>MOIA GmbH · Stadthausbrücke 8, 20355 Hamburg</span>
+            </div>
+          </div>
+          <p class="next-description">
+            We're back at MOIA for an evening of short talks, live demos, and
+            open discussion. The event is full — hop on the waitlist to grab a
+            spot if one opens up.
+          </p>
+          <a
+            href="https://luma.com/agentic-a7oi"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="next-cta"
+          >
+            Join the Waitlist
+            <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+            </svg>
           </a>
         </div>
       </div>
@@ -282,6 +337,108 @@ import PastEvents from "../components/PastEvents.astro";
   .link-icon {
     width: 1.25rem;
     height: 1.25rem;
+  }
+
+  /* Next Meetup Section */
+  .next-meetup {
+    background: white;
+  }
+
+  .next-card {
+    position: relative;
+    background: linear-gradient(
+      145deg,
+      var(--color-bg-soft) 0%,
+      var(--color-bg-light) 100%
+    );
+    border: 2px solid var(--color-primary);
+    border-radius: 20px;
+    padding: 2.5rem;
+    box-shadow: 0 4px 30px rgba(232, 136, 127, 0.12);
+  }
+
+  .next-badge {
+    display: inline-block;
+    background: var(--color-primary);
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.4rem 0.9rem;
+    border-radius: 50px;
+    margin-bottom: 1.25rem;
+  }
+
+  .next-title {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 800;
+    color: var(--color-text-primary);
+    margin-bottom: 1.25rem;
+  }
+
+  .next-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .next-detail {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: var(--color-text-secondary);
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .next-detail svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    color: var(--color-primary);
+    flex-shrink: 0;
+  }
+
+  .next-description {
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: var(--color-text-secondary);
+    margin-bottom: 1.75rem;
+    max-width: 600px;
+  }
+
+  .next-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--color-primary);
+    color: white;
+    padding: 1rem 2rem;
+    border-radius: 8px;
+    font-weight: 700;
+    font-size: 1.05rem;
+    text-decoration: none;
+    border: 2px solid var(--color-primary);
+    box-shadow: 0 4px 12px rgba(232, 136, 127, 0.3);
+    transition: all 0.3s ease;
+  }
+
+  .next-cta:hover {
+    background: var(--color-primary-light);
+    border-color: var(--color-primary-light);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(232, 136, 127, 0.4);
+  }
+
+  .next-cta svg {
+    width: 1.2rem;
+    height: 1.2rem;
+    transition: transform 0.3s ease;
+  }
+
+  .next-cta:hover svg {
+    transform: translateX(4px);
   }
 
   /* Format Section */


### PR DESCRIPTION
The Agentic Conf Hamburg (March 22, 2026) has happened, but the site still led with it as the upcoming "Sold Out" headline. This updates the homepage and meetups page to promote the next event — **Agentic Coding Meetup #5** (Tue, June 9, 2026 · 18:00–22:00 at MOIA GmbH) — and demote the conference to an archive.

## Homepage (`src/pages/index.astro`)
- Top banner → **Meetup #5** (June 9 · "Join the Waitlist", links to the [Luma page](https://luma.com/agentic-a7oi) in a new tab).
- Featured card is now the upcoming meetup (date/time, MOIA venue, waitlist CTA + "All meetups →").
- Conference demoted to a **"Past Event · March 22, 2026"** card, reworded to past tense, still linking to `/conf-2026`.
- Renamed misleading scoped classes (`.card-conference`/`.card-meetups` → `.card-featured`/`.card-secondary`) and removed orphaned CSS (`.badge-sold-out`, `.card-metrics`/`.metric*`).

## Meetups page (`src/pages/meetups.astro`)
- Banner swapped to the same Meetup #5 / waitlist banner.
- Added a **"Next Up"** card under the hero with full details (Tue June 9, 18:00–22:00 · MOIA GmbH, Stadthausbrücke 8, 20355 Hamburg) and a "Join the Waitlist" button.

## Verification
- `astro check`: 0 errors, 0 warnings. ESLint clean. Prettier applied. Full `astro build` succeeds.
- Verified live on the dev server: both pages return 200 and render the new content.

## Not included (follow-ups)
- Hero stat still reads "4 sold-out events" (`config/community.ts`) — bump to 5 after June 9.
- `/meetups` "Past Meetups" timeline still ends at #4 — move #5 there once it's happened.
- Dead components `EventCards.astro` / `ConferenceBanner.astro` still hold stale data and could be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)