### PR TITLE
Site update: Agentic Coding Meetup #6 (XING, 7 July)

### DIFF
--- a/src/components/PastEvents.astro
+++ b/src/components/PastEvents.astro
@@ -51,6 +51,15 @@ const defaultEvents: PastEvent[] = [
     attendees: 150,
     url: "https://lu.ma/4c9hr63k",
   },
+  {
+    title: "Meetup #5",
+    number: 5,
+    date: "June 9, 2026",
+    location: "Hamburg",
+    sponsor: "MOIA GmbH",
+    attendees: 120,
+    url: "https://luma.com/agentic-a7oi",
+  },
 ];
 
 const { events = defaultEvents } = Astro.props;

--- a/src/config/community.ts
+++ b/src/config/community.ts
@@ -8,7 +8,7 @@ export const communityStats = {
   memberCount: "1000+",
 
   // Number of meetups held
-  meetupCount: "4",
+  meetupCount: "5",
 
   // Talks and demos across all meetups
   talksAndDemos: "10+",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,15 +10,15 @@ import { communityStats } from "../config/community";
 
   <!-- Next Meetup Banner -->
   <a
-    href="https://luma.com/agentic-a7oi"
+    href="https://luma.com/agentic-ymzl"
     target="_blank"
     rel="noopener noreferrer"
     class="conf-banner"
   >
     <div class="banner-content">
-      <span class="banner-badge">June 9, 2026</span>
+      <span class="banner-badge">July 7, 2026</span>
       <span class="banner-text"
-        >Agentic Coding Meetup #5 @ MOIA — Join the Waitlist</span
+        >Agentic Coding Meetup #6 @ XING — Register on Luma</span
       >
       <svg
         class="banner-arrow"
@@ -110,16 +110,17 @@ import { communityStats } from "../config/community";
                   <rect x="3" y="4" width="18" height="18" rx="2"></rect>
                   <path d="M16 2v4M8 2v4M3 10h18"></path>
                 </svg>
-                June 9, 2026 · 18:00–22:00
+                July 7, 2026 · 18:00–22:00
               </div>
 
               <h3 class="card-title">
-                Agentic Coding<br />Meetup #5
+                Agentic Coding<br />Meetup #6
               </h3>
 
               <p class="card-description">
-                Talks, live demos, and networking with Hamburg's agentic coding
-                community — the next chapter after a sold-out conference.
+                Two talks, lightning demos (5 min, no pitches), and networking
+                with Hamburg's agentic coding community — hosted by XING at their
+                new Baumwall office.
               </p>
 
               <div class="card-venue">
@@ -133,17 +134,17 @@ import { communityStats } from "../config/community";
                   <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"></path>
                   <circle cx="12" cy="10" r="3"></circle>
                 </svg>
-                <span>MOIA GmbH · Stadthausbrücke 8, Hamburg</span>
+                <span>XING · Baumwall 7, 20459 Hamburg</span>
               </div>
 
               <div class="card-actions">
                 <a
-                  href="https://luma.com/agentic-a7oi"
+                  href="https://luma.com/agentic-ymzl"
                   target="_blank"
                   rel="noopener noreferrer"
                   class="btn-primary"
                 >
-                  <span>Join the Waitlist</span>
+                  <span>Register on Luma</span>
                   <svg
                     viewBox="0 0 24 24"
                     fill="none"

--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -13,15 +13,15 @@ import PastEvents from "../components/PastEvents.astro";
 
   <!-- Next Meetup Banner -->
   <a
-    href="https://luma.com/agentic-a7oi"
+    href="https://luma.com/agentic-ymzl"
     target="_blank"
     rel="noopener noreferrer"
     class="conf-banner"
   >
     <div class="banner-content">
-      <span class="banner-badge">June 9, 2026</span>
+      <span class="banner-badge">July 7, 2026</span>
       <span class="banner-text"
-        >Agentic Coding Meetup #5 @ MOIA — Join the Waitlist</span
+        >Agentic Coding Meetup #6 @ XING — Register on Luma</span
       >
       <svg
         class="banner-arrow"
@@ -68,7 +68,7 @@ import PastEvents from "../components/PastEvents.astro";
       <div class="mx-auto max-w-4xl px-4 py-12">
         <div class="next-card">
           <span class="next-badge">Next Up</span>
-          <h2 class="next-title">Agentic Coding Meetup #5</h2>
+          <h2 class="next-title">Agentic Coding Meetup #6</h2>
           <div class="next-details">
             <div class="next-detail">
               <svg fill="currentColor" viewBox="0 0 20 20">
@@ -77,7 +77,7 @@ import PastEvents from "../components/PastEvents.astro";
                   d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
                   clip-rule="evenodd"></path>
               </svg>
-              <span>Tuesday, June 9, 2026 · 18:00–22:00</span>
+              <span>Tuesday, July 7, 2026 · 18:00–22:00</span>
             </div>
             <div class="next-detail">
               <svg fill="currentColor" viewBox="0 0 20 20">
@@ -86,21 +86,21 @@ import PastEvents from "../components/PastEvents.astro";
                   d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
                   clip-rule="evenodd"></path>
               </svg>
-              <span>MOIA GmbH · Stadthausbrücke 8, 20355 Hamburg</span>
+              <span>XING (New Work SE) · Baumwall 7, 20459 Hamburg</span>
             </div>
           </div>
           <p class="next-description">
-            We're back at MOIA for an evening of short talks, live demos, and
-            open discussion. The event is full — hop on the waitlist to grab a
-            spot if one opens up.
+            XING hosts us at their new Baumwall office for an evening of two
+            talks, lightning demos (5 minutes, no pitches), and open discussion.
+            Free — grab a seat on Luma.
           </p>
           <a
-            href="https://luma.com/agentic-a7oi"
+            href="https://luma.com/agentic-ymzl"
             target="_blank"
             rel="noopener noreferrer"
             class="next-cta"
           >
-            Join the Waitlist
+            Register on Luma
             <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path
                 stroke-linecap="round"


### PR DESCRIPTION
Updates the site for **Agentic Coding Meetup #6**, hosted by XING at their new Baumwall office.

**Event:** Tue 7 July 2026 · 18:00–22:00 · XING (New Work SE), Baumwall 7, 20459 Hamburg
**Register:** https://luma.com/agentic-ymzl (Luma only — meetup.com is announce-only)

### Changes
- **`index.astro`** — top banner + "Upcoming" card → #6 @ XING, 7 July, CTA "Register on Luma"
- **`meetups.astro`** — next-up banner + card → #6 (date, venue, copy, CTA)
- **`PastEvents.astro`** — add #5 (MOIA, 9 June) to the timeline
- **`community.ts`** — `meetupCount` 4 → 5

### Notes
- `#5` attendee count set to **120** (from ~119 Luma registrations) — replace with the real figure if known.
- `EventCards.astro` is unused (imported nowhere) and left untouched.
- `astro check` passes: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)