### PR TITLE
Announce Meetup #6 talks: Malte Burkert + lightning lineup

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -118,9 +118,10 @@ import { communityStats } from "../config/community";
               </h3>
 
               <p class="card-description">
-                Two talks, lightning demos (5 min, no pitches), and networking
-                with Hamburg's agentic coding community — hosted by XING at their
-                new Baumwall office.
+                Headlined by Malte Burkert (WAPP) on why review becomes the
+                bottleneck when agents write the code — plus lightning demos, and
+                networking with Hamburg's agentic coding community. Hosted by XING
+                at their new Baumwall office.
               </p>
 
               <div class="card-venue">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -134,7 +134,7 @@ import { communityStats } from "../config/community";
                   <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0118 0z"></path>
                   <circle cx="12" cy="10" r="3"></circle>
                 </svg>
-                <span>XING · Baumwall 7, 20459 Hamburg</span>
+                <span>XING · Baumwall, Hamburg</span>
               </div>
 
               <div class="card-actions">

--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -86,7 +86,7 @@ import PastEvents from "../components/PastEvents.astro";
                   d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
                   clip-rule="evenodd"></path>
               </svg>
-              <span>XING (New Work SE) · Baumwall 7, 20459 Hamburg</span>
+              <span>XING (New Work SE) · Baumwall, Hamburg</span>
             </div>
           </div>
           <p class="next-description">

--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -94,6 +94,76 @@ import PastEvents from "../components/PastEvents.astro";
             talks, lightning demos (5 minutes, no pitches), and open discussion.
             Free — grab a seat on Luma.
           </p>
+
+          <div class="next-program">
+            <h3 class="program-heading">On the program</h3>
+            <ul class="program-list">
+              <li class="program-item">
+                <span class="program-tag program-tag--talk">Talk</span>
+                <div class="program-body">
+                  <span class="program-title"
+                    >When Agents Write the Code, Review Becomes the Bottleneck</span
+                  >
+                  <span class="program-speaker">
+                    Malte Burkert · WAPP
+                    <a
+                      href="https://www.linkedin.com/in/malte-burkert-3761b7155/"
+                      target="_blank"
+                      rel="noopener noreferrer">LinkedIn ↗</a
+                    >
+                  </span>
+                  <span class="program-abstract">
+                    A 20-person agency went all-in on agentic engineering and
+                    watched its review queue eat an entire sprint. What actually
+                    broke — and the four numbers they now track to know whether
+                    it's working.
+                  </span>
+                </div>
+              </li>
+              <li class="program-item">
+                <span class="program-tag program-tag--lightning">Lightning</span>
+                <div class="program-body">
+                  <span class="program-title">Sandcastle</span>
+                  <span class="program-speaker">
+                    Thies Arntzen
+                    <a
+                      href="https://github.com/thieso2/sandcastle"
+                      target="_blank"
+                      rel="noopener noreferrer">GitHub ↗</a
+                    >
+                  </span>
+                  <span class="program-abstract">
+                    Self-hosted, isolated Docker sandboxes (SSH + a full Docker
+                    daemon inside) for letting coding agents run loose safely.
+                  </span>
+                </div>
+              </li>
+              <li class="program-item">
+                <span class="program-tag program-tag--lightning">Lightning</span>
+                <div class="program-body">
+                  <span class="program-title">haze</span>
+                  <span class="program-speaker">
+                    Deniz Okcu
+                    <a
+                      href="https://denizokcu.github.io/haze/"
+                      target="_blank"
+                      rel="noopener noreferrer">Project ↗</a
+                    >
+                  </span>
+                  <span class="program-abstract">
+                    A minimal terminal coding agent — bring your own LLM, hand it
+                    a few sharp tools, then get out of the way (custom Markdown
+                    "skills" as slash commands).
+                  </span>
+                </div>
+              </li>
+            </ul>
+            <p class="program-note">
+              Plus a second talk to be announced and more lightning slots open —
+              <a href="mailto:hello@agentic.hamburg">pitch us a 5-minute demo</a>.
+            </p>
+          </div>
+
           <a
             href="https://luma.com/agentic-ymzl"
             target="_blank"
@@ -406,6 +476,117 @@ import PastEvents from "../components/PastEvents.astro";
     color: var(--color-text-secondary);
     margin-bottom: 1.75rem;
     max-width: 600px;
+  }
+
+  /* On the program */
+  .next-program {
+    margin-bottom: 1.75rem;
+  }
+
+  .program-heading {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--color-primary);
+    margin-bottom: 1rem;
+  }
+
+  .program-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .program-item {
+    display: flex;
+    gap: 0.85rem;
+    align-items: flex-start;
+    background: white;
+    border: 1px solid rgba(44, 62, 58, 0.08);
+    border-radius: 12px;
+    padding: 1rem 1.1rem;
+  }
+
+  .program-tag {
+    flex-shrink: 0;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.25rem 0.55rem;
+    border-radius: 50px;
+    margin-top: 0.15rem;
+  }
+
+  .program-tag--talk {
+    background: var(--color-primary);
+    color: white;
+  }
+
+  .program-tag--lightning {
+    background: rgba(44, 62, 58, 0.08);
+    color: var(--color-text-secondary);
+  }
+
+  .program-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 0;
+  }
+
+  .program-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    line-height: 1.3;
+  }
+
+  .program-speaker {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .program-speaker a {
+    font-weight: 600;
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .program-speaker a:hover {
+    text-decoration: underline;
+  }
+
+  .program-abstract {
+    font-size: 0.85rem;
+    line-height: 1.55;
+    color: var(--color-text-secondary);
+    margin-top: 0.15rem;
+  }
+
+  .program-note {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary);
+    margin-top: 1rem;
+  }
+
+  .program-note a {
+    color: var(--color-primary);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .program-note a:hover {
+    text-decoration: underline;
   }
 
   .next-cta {


### PR DESCRIPTION
## Meetup #6 — announce the talks

Surfaces the confirmed program for **Agentic Coding Meetup #6** (7 July, XING) on the site, matching what's now live on Luma (https://luma.com/agentic-ymzl).

**Program added (`meetups.astro`)** — new "On the program" block on the Next Up card:
- **Talk** — Malte Burkert (WAPP): *When Agents Write the Code, Review Becomes the Bottleneck* → LinkedIn
- **Lightning** — Thies Arntzen: *Sandcastle* → GitHub
- **Lightning** — Deniz Okcu: *haze* → project

**Homepage (`index.astro`)** — the next-meetup card now leads with the headline talk instead of generic copy.

Also carries the previously-unmerged venue-wording commit (`3c58d2a`) that drops the exact street address (`Baumwall 7, 20459 Hamburg` → `Baumwall, Hamburg`).

Verified: `astro check` clean (0 errors), full build succeeds, rendered HTML contains all three talks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)