### PR TITLE
Add Talk #2 to Meetup #6 program: AutoFleetControl

### DIFF
--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -121,6 +121,29 @@ import PastEvents from "../components/PastEvents.astro";
                 </div>
               </li>
               <li class="program-item">
+                <span class="program-tag program-tag--talk">Talk</span>
+                <div class="program-body">
+                  <span class="program-title"
+                    >Agentic Coding Ate Our IT Department</span
+                  >
+                  <span class="program-speaker">
+                    Daniel Schreiber &amp; Felix · AutoFleetControl
+                    <a
+                      href="https://www.autofleetcontrol.de"
+                      target="_blank"
+                      rel="noopener noreferrer">Website ↗</a
+                    >
+                  </span>
+                  <span class="program-abstract">
+                    Two non-developers built a 116K-line production system with
+                    AI agents — then it scaled and stopped being a coding story.
+                    How AFC's IT department became a Product Engineering org:
+                    changing roles, ownership, and what breaks when agentic
+                    coding meets legacy at scale.
+                  </span>
+                </div>
+              </li>
+              <li class="program-item">
                 <span class="program-tag program-tag--lightning">Lightning</span>
                 <div class="program-body">
                   <span class="program-title">Sandcastle</span>
@@ -159,7 +182,7 @@ import PastEvents from "../components/PastEvents.astro";
               </li>
             </ul>
             <p class="program-note">
-              Plus a second talk to be announced and more lightning slots open —
+              More lightning slots open —
               <a href="mailto:hello@agentic.hamburg">pitch us a 5-minute demo</a>.
             </p>
           </div>


### PR DESCRIPTION
Fills the second main-talk slot on the Meetup #6 Next Up card (`meetups.astro`), matching what's now live on Luma (https://luma.com/agentic-ymzl).

**Talk #2** — *Agentic Coding Ate Our IT Department* — Daniel Schreiber & Felix (AutoFleetControl). Short blurb + link to autofleetcontrol.de. Part 2 of their Agentic Conf Hamburg talk.

Also drops the now-stale "second talk to be announced" line from the program note.

Verified: `astro check` clean (0 errors), build succeeds, rendered HTML contains the new talk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)