### PR TITLE
Add lightning talk to Meetup #6: Korfmann (Prism × Helmut)

### DIFF
--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -180,6 +180,32 @@ import PastEvents from "../components/PastEvents.astro";
                   </span>
                 </div>
               </li>
+              <li class="program-item">
+                <span class="program-tag program-tag--lightning">Lightning</span>
+                <div class="program-body">
+                  <span class="program-title"
+                    >I Built a Browser Engine So a Yeti Could Rap</span
+                  >
+                  <span class="program-speaker">
+                    Sebastian Korfmann
+                    <a
+                      href="https://jot.skorfmann.com/prism-renderer/"
+                      target="_blank"
+                      rel="noopener noreferrer">Prism ↗</a
+                    >
+                    <a
+                      href="https://helmut.rocks/"
+                      target="_blank"
+                      rel="noopener noreferrer">helmut.rocks ↗</a
+                    >
+                  </span>
+                  <span class="program-abstract">
+                    A from-scratch WASM browser engine, a rapping Yeti, and the
+                    long agent loops that produced both — colliding live on
+                    stage.
+                  </span>
+                </div>
+              </li>
             </ul>
             <p class="program-note">
               More lightning slots open —


### PR DESCRIPTION
Adds a confirmed lightning talk to the Meetup #6 program (`meetups.astro`), matching Luma (https://luma.com/agentic-ymzl).

**Lightning** — *I Built a Browser Engine So a Yeti Could Rap* — Sebastian Korfmann. A from-scratch WASM browser engine (Prism) and a rapping-Yeti music video (Helmut), both built with long-running coding-agent loops — colliding live on stage. Links: prism-renderer + helmut.rocks.

Verified: `astro check` clean (0 errors), build succeeds, rendered HTML contains the new talk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)