### PR TITLE
Meetup #6: remove Thies (Sandcastle) lightning talk, add Lior Oren

### DIFF
--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -146,24 +146,6 @@ import PastEvents from "../components/PastEvents.astro";
               <li class="program-item">
                 <span class="program-tag program-tag--lightning">Lightning</span>
                 <div class="program-body">
-                  <span class="program-title">Sandcastle</span>
-                  <span class="program-speaker">
-                    Thies Arntzen
-                    <a
-                      href="https://github.com/thieso2/sandcastle"
-                      target="_blank"
-                      rel="noopener noreferrer">GitHub ↗</a
-                    >
-                  </span>
-                  <span class="program-abstract">
-                    Self-hosted, isolated Docker sandboxes (SSH + a full Docker
-                    daemon inside) for letting coding agents run loose safely.
-                  </span>
-                </div>
-              </li>
-              <li class="program-item">
-                <span class="program-tag program-tag--lightning">Lightning</span>
-                <div class="program-body">
                   <span class="program-title">haze</span>
                   <span class="program-speaker">
                     Deniz Okcu
@@ -203,6 +185,26 @@ import PastEvents from "../components/PastEvents.astro";
                     A from-scratch WASM browser engine, a rapping Yeti, and the
                     long agent loops that produced both — colliding live on
                     stage.
+                  </span>
+                </div>
+              </li>
+              <li class="program-item">
+                <span class="program-tag program-tag--lightning">Lightning</span>
+                <div class="program-body">
+                  <span class="program-title"
+                    >Conversational AI Design System Under the Hood</span
+                  >
+                  <span class="program-speaker">
+                    Lior Oren
+                    <a
+                      href="https://www.linkedin.com/in/lior-oren/"
+                      target="_blank"
+                      rel="noopener noreferrer">LinkedIn ↗</a
+                    >
+                  </span>
+                  <span class="program-abstract">
+                    A look inside the design system that powers a
+                    conversational-AI product.
                   </span>
                 </div>
               </li>


### PR DESCRIPTION
Updates the Meetup #6 lightning-talk lineup on `meetups.astro`:

- **Removed:** Sandcastle — Thies Arntzen
- **Added:** Conversational AI Design System Under the Hood — Lior Oren ([LinkedIn](https://www.linkedin.com/in/lior-oren/))

Matches the live Luma event (already updated). `astro check` passes (0 errors, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)